### PR TITLE
Refactors and adds optional config for error display

### DIFF
--- a/doc/stylua-nvim.txt
+++ b/doc/stylua-nvim.txt
@@ -32,9 +32,18 @@ Install via your favorite package manager.
 LUA API                                                    *stylua-nvim-lua-api*
 
 
-                                                                 *format_file()*
-format_file()           Use to format the current buffer. If any issues are
+                                                           *format_file(config)*
+format_file(config)     Use to format the current buffer. If any issues are
                         found, they will be opened in your loclist.
+
+                        Takes an optional configuration argument
+                        {
+                          error_display_strategy = <error_display_string>
+                        }
+
+                        <error_display_string> options currently are:
+                        * "loclist": display errors in a location list
+                        * "none": do not display stylua errors
 
 ================================================================================
 Example Usage                                              *stylua-nvim-lua-api*

--- a/lua/stylua-nvim.lua
+++ b/lua/stylua-nvim.lua
@@ -3,7 +3,13 @@ local fn = vim.fn
 
 local M = {}
 
-local state = { had_format_err = false }
+local state = {
+  had_format_err = false,
+}
+
+local config = {
+  error_display_strategy = "loclist",
+}
 
 local function buf_get_full_text(bufnr)
   local text = table.concat(api.nvim_buf_get_lines(bufnr, 0, -1, true), "\n")
@@ -13,16 +19,60 @@ local function buf_get_full_text(bufnr)
   return text
 end
 
-M.format_file = function()
-  local flags
-  local error_file = fn.tempname()
+local function create_flags()
   local config_file = fn.findfile("stylua.toml", ".;")
-
   if fn.empty(config_file) == 0 then
-    flags = "--config-path " .. config_file
+    return "--config-path " .. config_file
   else
-    flags = ""
+    return ""
   end
+end
+
+local function no_errors(output, input)
+  if output ~= input then
+    local new_lines = vim.fn.split(output, "\n")
+    api.nvim_buf_set_lines(0, 0, -1, false, new_lines)
+  end
+  -- We try a little bit to make sure we aren't closing a loclist that we didn't create.
+  -- This isn't perfect in the case of long sessions, but probably better than nothing.
+  if config.error_display_strategy == "loclist" and state.had_format_err then
+    vim.fn.setloclist(0, {})
+    vim.cmd("lclose")
+  end
+end
+
+local function handle_errors(error_file)
+  local errors = table.concat(vim.fn.readfile(error_file), " ")
+
+  -- A little hacky, but we know that the error messsages are always shaped
+  -- in a similiar way containing:
+  --(starting from line 32, character 2 and ending on line 32, character 5)
+  -- So we know that:
+  --	- locations[1] = start line
+  --	- locations[2] = start col
+  --	- locations[3] = end line
+  --	- locations[4] = end col
+  local locations = {}
+  for num in errors:gmatch("%d+") do
+    table.insert(locations, num)
+  end
+
+  -- Ensure that we have the full range
+  if table.getn(locations) == 4 then
+    if config.error_display_strategy == "loclist" then
+      vim.fn.setloclist(0, { { bufnr = 0, lnum = locations[1], col = locations[2], text = errors } })
+      vim.cmd("lopen")
+    end
+    state.had_format_err = true
+  end
+end
+
+M.format_file = function(user_config)
+  if user_config and user_config.error_display_strategy then
+    config.error_display_strategy = user_config.error_display_strategy
+  end
+  local error_file = fn.tempname()
+  local flags = create_flags()
 
   local stylua_command = string.format("stylua %s - 2> %s", flags, error_file)
 
@@ -30,38 +80,9 @@ M.format_file = function()
   local output = fn.system(stylua_command, input)
 
   if fn.empty(output) == 0 then
-    if output ~= input then
-      local new_lines = vim.fn.split(output, "\n")
-      api.nvim_buf_set_lines(0, 0, -1, false, new_lines)
-    end
-    -- We try a little bit to make sure we aren't closing a loclist that we didn't create.
-    -- This isn't perfect in the case of long sessions, but probably better than nothing.
-    if state.had_format_err then
-      vim.fn.setloclist(0, {})
-      vim.cmd("lclose")
-    end
+    no_errors(output, input)
   else
-    local errors = table.concat(vim.fn.readfile(error_file), " ")
-
-    -- A little hacky, but we know that the error messsages are always shaped
-    -- in a similiar way containing:
-    --(starting from line 32, character 2 and ending on line 32, character 5)
-    -- So we know that:
-    --	- locations[1] = start line
-    --	- locations[2] = start col
-    --	- locations[3] = end line
-    --	- locations[4] = end col
-    local locations = {}
-    for num in errors:gmatch("%d+") do
-      table.insert(locations, num)
-    end
-
-    -- Ensure that we have the full range
-    if table.getn(locations) == 4 then
-      vim.fn.setloclist(0, { { bufnr = 0, lnum = locations[1], col = locations[2], text = errors } })
-      vim.cmd("lopen")
-      state.had_format_err = true
-    end
+    handle_errors(error_file)
   end
 
   fn.delete(error_file)


### PR DESCRIPTION
Hey, thanks so much for the plugin, I hope you don't mind but while I was adding this configuration I made a slight tweak to some of the code organization. If you hate it I'd totally be willing to change it.
The inspiration for this was that I didn't want the loclist opened or populated any time I have formatting errors (I use it for other things).

This configuration argument is entirely optional but allows the user to
specify how they want formatting errors presented (even though loclist is the only supported value that does anything).
I also set up configuration state to make similar changes easier in the
future.