### PR TITLE
Fix duplicate helptag

### DIFF
--- a/doc/stylua-nvim.txt
+++ b/doc/stylua-nvim.txt
@@ -67,7 +67,7 @@ format_file(config)     Use to format the current buffer. If any issues are
                         * "none": do not display stylua errors
 
 ================================================================================
-Example Usage                                              *stylua-nvim-lua-api*
+Example Usage                                        *stylua-nvim-example-usage*
 
 
 Via a mapping: >


### PR DESCRIPTION
The Example Usage section of the help text has a duplicate tag, which
results in the following error from `:helptag`:

    E154: Duplicate tag "stylua-nvim-lua-api" in file ./doc/stylua-nvim.txt

Renaming the duplicate helptag to match what's used in the CONTENTS
fixes the issue.